### PR TITLE
Use conda-forge's pytorch pin

### DIFF
--- a/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13python3.10.____cpython.yaml
@@ -28,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+pytorch:
+- '2.5'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13python3.11.____cpython.yaml
@@ -28,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+pytorch:
+- '2.5'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13python3.12.____cpython.yaml
@@ -28,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.12.* *_cpython
+pytorch:
+- '2.5'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13python3.9.____cpython.yaml
@@ -28,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.9.* *_cpython
+pytorch:
+- '2.5'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython.yaml
@@ -28,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+pytorch:
+- '2.5'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.11.____cpython.yaml
@@ -28,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+pytorch:
+- '2.5'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.12.____cpython.yaml
@@ -28,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.12.* *_cpython
+pytorch:
+- '2.5'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.9.____cpython.yaml
@@ -28,6 +28,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.9.* *_cpython
+pytorch:
+- '2.5'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/migrations/pytorch25.yaml
+++ b/.ci_support/migrations/pytorch25.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for pytorch 2.5
+  kind: version
+  migration_number: 1
+libtorch:
+- '2.5'
+migrator_ts: 1730666768.682698
+pytorch:
+- '2.5'

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -30,6 +30,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+pytorch:
+- '2.5'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -30,6 +30,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+pytorch:
+- '2.5'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -30,6 +30,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.12.* *_cpython
+pytorch:
+- '2.5'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -30,6 +30,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.9.* *_cpython
+pytorch:
+- '2.5'
 target_platform:
 - osx-64
 zip_keys:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -44,6 +44,7 @@ requirements:
     - if: cuda_compiler_version != "None"
       then:
         - cuda-version ==${{ cuda_compiler_version }}
+    - pytorch
     - pytorch * [build=${{ torch_proc_type }}*]
   run:
     - python

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ context:
   # note v1.9.0 tag is the same as v0.1.9, except for CI changes,
   # and it installs as torchsort-0.1.9
   version: 0.1.9
-  build_number: 0
+  build_number: 1
   torch_proc_type: ${{ "cuda" ~ cuda_compiler_version | version_to_buildstring if cuda_compiler_version != "None" else "cpu" }}
 
 package:


### PR DESCRIPTION
Otherwise you get a free-floating "highest available pytorch"; which isn't helpful from a compatibility POV.